### PR TITLE
Left axe.json blank (#4)

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -1,6 +1,3 @@
 {
-    "replace": false,
-    "values": [
-        "evenmoreinstruments:looper"
-    ]
+    "replace": false
 }

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -1,4 +1,5 @@
 {
+    "replace": false,
     "values": [
         "evenmoreinstruments:looper"
     ]


### PR DESCRIPTION
The looper item you referenced isn't implemented (or registered, I haven't checked)

This fixes #4 properly